### PR TITLE
add non-long-run topology API for tasks like exporting result to kafka

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod model;
 mod memory_queue_client;
 
 use crate::topology_controller::TopologyController;
-use crate::topology_controller::run_topology_once;
+use crate::topology_controller::OneShotTopologyController;
 use crate::memory_queue_client::MemoryQueueClient;
 use crate::model::CxxLogEvent;
 
@@ -61,7 +61,14 @@ mod ffi {
     }
 
     extern "Rust" {
-        fn run_topology(config: String) -> Result<bool>;
+        /**
+         * OneShotTopologyController
+         */
+        type OneShotTopologyController;
+
+        fn new_one_shot_topology_controller() -> Box<OneShotTopologyController>;
+
+        fn start(self: &mut OneShotTopologyController, topology_config: &str) -> Result<bool>;
     }
 }
 
@@ -69,16 +76,10 @@ pub fn new_topology_controller() -> Box<TopologyController> {
     Box::new(TopologyController::new())
 }
 
-pub fn new_memory_queue_client() -> Box<MemoryQueueClient> {
-    Box::new(MemoryQueueClient::new())
+pub fn new_one_shot_topology_controller() -> Box<OneShotTopologyController> {
+    Box::new(OneShotTopologyController::new())
 }
 
-// used to run a one time topology, which will exit after source consuming finished.
-pub fn run_topology(config: String) -> Result<bool, String> {
-    let (res, err_msg) = run_topology_once(config.as_str());
-    return if res {
-        Ok(true)
-    } else {
-        Err(err_msg)
-    }
+pub fn new_memory_queue_client() -> Box<MemoryQueueClient> {
+    Box::new(MemoryQueueClient::new())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod model;
 mod memory_queue_client;
 
 use crate::topology_controller::TopologyController;
+use crate::topology_controller::run_topology_once;
 use crate::memory_queue_client::MemoryQueueClient;
 use crate::model::CxxLogEvent;
 
@@ -58,6 +59,10 @@ mod ffi {
 
         fn poll(self: &mut MemoryQueueClient) -> Vec<CxxLogEvent>;
     }
+
+    extern "Rust" {
+        fn run_topology(config: String) -> Result<bool>;
+    }
 }
 
 pub fn new_topology_controller() -> Box<TopologyController> {
@@ -66,4 +71,14 @@ pub fn new_topology_controller() -> Box<TopologyController> {
 
 pub fn new_memory_queue_client() -> Box<MemoryQueueClient> {
     Box::new(MemoryQueueClient::new())
+}
+
+// used to run a one time topology, which will exit after source consuming finished.
+pub fn run_topology(config: String) -> Result<bool, String> {
+    let (res, err_msg) = run_topology_once(config.as_str());
+    return if res {
+        Ok(true)
+    } else {
+        Err(err_msg)
+    }
 }

--- a/src/topology_controller.rs
+++ b/src/topology_controller.rs
@@ -186,12 +186,12 @@ impl TopologyController {
 
     // run a topology with tokio runtime
     pub fn start(&mut self, topology_config: &str) -> Result<bool, String> {
-        info!("start vector service");
 
         let builder = init_config(topology_config);
         if builder.is_none() {
             return Err("failed to init topology config".to_string());
         }
+        info!("start vector service");
 
         let config_builder = builder.unwrap();
         *self.config_builder.lock().unwrap() = Some(config_builder.clone());
@@ -302,11 +302,11 @@ impl OneShotTopologyController {
 
     // run topology and return after finished, no need to maintain datas for long run
     pub fn start(&mut self, config_str: &str) -> Result<bool, String> {
-        info!("start one time vector topology");
         let config_builder = init_config(config_str);
         if config_builder.is_none() {
             return Err("failed to init topology config".to_string());
         }
+        info!("start one time vector topology");
 
         let config = config_builder.unwrap().build().unwrap();
         info!("config constructed via config builder");

--- a/src/topology_controller.rs
+++ b/src/topology_controller.rs
@@ -2,9 +2,9 @@ use crate::config_event::{ConfigAction, ConfigEvent};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
 use tracing::{debug, error, info, Level};
-use vector::config::ConfigBuilder;
-use vector::config::ComponentKey;
+use vector::config::{ConfigBuilder, Config, ComponentKey, ConfigDiff};
 use vector::topology::RunningTopology;
 use vector::{config, config::format, metrics, test_util::runtime};
 
@@ -29,10 +29,6 @@ pub fn setup_logging() {
         .with_timer(timer)
         .finish();
     tracing::subscriber::set_global_default(collector).expect("setting default subscriber failed");
-}
-
-fn increment_generation_id(generation_id: &AtomicU32) {
-    generation_id.fetch_add(1, Ordering::Relaxed);
 }
 
 fn _print_ids(config: &mut ConfigBuilder) {
@@ -137,6 +133,42 @@ async fn reload_vector(
     true
 }
 
+fn advance_generation(result: bool, generation_id: &AtomicU32) -> bool {
+    if result {
+        generation_id.fetch_add(1, Ordering::Relaxed);
+    }
+    result
+}
+
+pub fn init_config(config_str: &str) -> Option<ConfigBuilder> {
+    START.call_once(|| {
+        setup_logging();
+    });
+
+    let res = format::deserialize(config_str, config::Format::Json);
+    if res.is_err() {
+        error!("deserialize error {:?}", res.unwrap_err());
+        return None;
+    }
+    let config_builder: ConfigBuilder = res.unwrap();
+    debug!(
+        "config_builder deserialized; sources={:?} transforms={:?} sinks={:?} global={:?}",
+        config_builder.sources,
+        config_builder.transforms,
+        config_builder.sinks,
+        config_builder.global
+    );
+    INIT.call_once(|| {
+        let builder_for_schema = config_builder.clone();
+        let _init_result = config::init_log_schema_from_builder(builder_for_schema, false).expect("init log schema failed");
+        #[cfg(not(feature = "enterprise-tests"))]
+        metrics::init_global().expect("metrics initialization failed");
+    });
+
+    info!("config constructed via config builder");
+    Some(config_builder)
+}
+
 impl TopologyController {
     pub fn new() -> Self {
         Self {
@@ -149,33 +181,15 @@ impl TopologyController {
     }
 
     // run a topology with tokio runtime
-    pub fn start(&mut self, topology_config: &str) -> Result<bool, &'static str> {
-        START.call_once(|| {
-            setup_logging();
-        });
-
+    pub fn start(&mut self, topology_config: &str) -> Result<bool, String> {
         info!("start vector service");
 
-        let res = format::deserialize(topology_config, config::Format::Json);
-        if res.is_err() {
-            error!("deserialize error {:?}", res.unwrap_err());
-            return Err("failed to deserialize config string");
+        let builder = init_config(topology_config);
+        if builder.is_none() {
+            return Err("failed to init topology config".to_string());
         }
-        let config_builder: ConfigBuilder = res.unwrap();
-        debug!(
-            "config_builder deserialized; sources={:?} transforms={:?} sinks={:?} global={:?}",
-            config_builder.sources,
-            config_builder.transforms,
-            config_builder.sinks,
-            config_builder.global
-        );
-        INIT.call_once(|| {
-            let builder_for_schema = config_builder.clone();
-            let _init_result = config::init_log_schema_from_builder(builder_for_schema, false).expect("init log schema failed");
-            #[cfg(not(feature = "enterprise-tests"))]
-            metrics::init_global().expect("metrics initialization failed");
-        });
 
+        let config_builder = builder.unwrap();
         *self.config_builder.lock().unwrap() = Some(config_builder.clone());
         let topology_cp = self.topology.clone();
         let config = config_builder.build().unwrap();
@@ -201,35 +215,23 @@ impl TopologyController {
 
     pub fn add_config(&mut self, config: String) -> bool {
         let res = self.rt.block_on(self.handle_config_event("add".to_string(), vec![], config));
-        if res {
-            increment_generation_id(&self.generation_id);
-        }
-        res
+        advance_generation(res, &self.generation_id)
     }
 
     pub fn delete_config(&mut self, config_ids: Vec<String>) -> bool {
         let res = self.rt.block_on(self.handle_config_event("delete".to_string(), config_ids, "".to_string()));
-        if res {
-            increment_generation_id(&self.generation_id);
-        }
-        res
+        advance_generation(res, &self.generation_id)
     }
 
     pub fn update_config(&mut self, config: String) -> bool {
         let res = self.rt.block_on(self.handle_config_event("update".to_string(), vec![], config));
-        if res {
-            increment_generation_id(&self.generation_id);
-        }
-        res
+        advance_generation(res, &self.generation_id)
     }
 
     pub fn exit(&mut self) -> bool {
         // no need to handle config event, stop topology directly.
         let res = self.stop();
-        if res {
-            increment_generation_id(&self.generation_id);
-        }
-        res
+        advance_generation(res, &self.generation_id)
     }
 
     pub fn stop(&mut self) -> bool {
@@ -285,4 +287,44 @@ impl TopologyController {
             config_str,
         }, self.config_builder.lock().unwrap().as_mut().unwrap(), self.topology.lock().unwrap().as_mut().unwrap()).await
     }
+}
+
+// this function start topology and waiting for source finished
+pub async fn start_topology_sync(
+    mut config: Config,
+    require_healthy: impl Into<Option<bool>>,
+) -> (bool, String) {
+    config.healthchecks.set_require_healthy(require_healthy);
+    let diff = ConfigDiff::initial(&config);
+    let pieces = vector::topology::build_or_log_errors(&config, &diff, HashMap::new())
+        .await
+        .unwrap();
+    let result = vector::topology::start_validated(config, diff, pieces).await;
+    if result.is_none() {
+        return (false, "health check for sink failed".to_string());
+    }
+
+    let (topology, _crash) = result.unwrap();
+    topology.sources_finished().await;
+    topology.stop().await;
+    (true, String::new())
+}
+
+// run topology and return after finished, no need to maintain datas for long run
+pub fn run_topology_once(config_str: &str) -> (bool, String) {
+    info!("start one time vector topology");
+    let config_builder = init_config(config_str);
+    if config_builder.is_none() {
+        return (false, "failed to init topology config".to_string());
+    }
+
+    let config = config_builder.unwrap().build().unwrap();
+    info!("config constructed via config builder");
+
+    let rt = runtime();
+    let res = rt.block_on(async {
+        let (res, err) = start_topology_sync(config, true).await;
+        (res, err)
+    });
+    return res;
 }

--- a/tests/data/batch_file_to_file.json
+++ b/tests/data/batch_file_to_file.json
@@ -1,0 +1,26 @@
+{
+  "data_dir": "/tmp/vector/",
+  "sources": {
+    "source_file": {
+      "type": "file",
+      "read_from": "beginning",
+      "include": [
+        "../tests/data/test_files/vector_test_source.log"
+      ],
+      "ignore_checkpoints": true,
+      "keep_watching": false
+    }
+  },
+  "sinks": {
+    "sink_file": {
+      "type": "file",
+      "inputs": [
+        "source_*"
+      ],
+      "encoding": {
+        "codec": "json"
+      },
+      "path": "/tmp/vector_test_sink.log"
+    }
+  }
+}

--- a/tests/data/batch_file_to_kafka.json
+++ b/tests/data/batch_file_to_kafka.json
@@ -1,0 +1,30 @@
+{
+  "data_dir": "/tmp/vector/",
+  "sources": {
+    "source_file": {
+      "type": "file",
+      "read_from": "beginning",
+      "include": [
+        "../tests/data/test_files/vector_test_source.log"
+      ],
+      "ignore_checkpoints": true,
+      "keep_watching": false
+    }
+  },
+  "sinks": {
+    "sink_kafka": {
+      "type": "kafka",
+      "inputs": [
+        "source_*"
+      ],
+      "bootstrap_servers": "host.docker.internal:9092",
+      "topic": "test-topic",
+      "encoding": {
+        "codec": "json"
+      },
+      "healthcheck": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/tests/data/test_files/vector_test_source.log
+++ b/tests/data/test_files/vector_test_source.log
@@ -1,0 +1,2 @@
+line1
+line2

--- a/tests/memory_queue_client_test.cpp
+++ b/tests/memory_queue_client_test.cpp
@@ -16,6 +16,9 @@ TEST_CASE("consume events from memory queue") {
 
     auto &memory_queue_client = CxxMemoryQueueClient::get_instance();
     auto events = memory_queue_client->poll();
+    do {
+      events = memory_queue_client->poll();
+    } while (events.empty());
     REQUIRE(events.size() == 1);
     REQUIRE(events[0].get("_target_table") == "main");
     REQUIRE(events[0].get("source_type") == "http");

--- a/tests/memory_queue_client_test.cpp
+++ b/tests/memory_queue_client_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE("consume events from memory queue") {
     send_http_events({"e0", "e1"});
 
     auto &memory_queue_client = CxxMemoryQueueClient::get_instance();
-    auto events = memory_queue_client->poll();
+    rust::Vec<vectorcxx::CxxLogEvent> events;
     do {
       events = memory_queue_client->poll();
     } while (events.empty());
@@ -42,7 +42,10 @@ TEST_CASE("iterate field names from pulled events") {
   run("http_to_memory_queue", [](rust::Box<TopologyController> &tc) {
     send_http_events({"e0", "e1"});
     auto &memory_queue_client = CxxMemoryQueueClient::get_instance();
-    auto events = memory_queue_client->poll();
+    rust::Vec<vectorcxx::CxxLogEvent> events;
+    do {
+      events = memory_queue_client->poll();
+    } while (events.empty());
     REQUIRE(events.size() == 1);
     auto fields = events[0].fields();
     REQUIRE(fields.size() > 0);

--- a/tests/topology_test.cpp
+++ b/tests/topology_test.cpp
@@ -15,6 +15,7 @@ using vectorcxx::test::read_events_from_sink;
 using vectorcxx::test::load_config;
 using vectorcxx::test::wait;
 using vectorcxx::TopologyController;
+using vectorcxx::run_topology;
 
 TEST_CASE("start single event http to file topology") {
   run("http_to_file",
@@ -45,7 +46,6 @@ TEST_CASE("start http to file with transform topology") {
 TEST_CASE("add new source to topology") {
   run("file_to_file", [](rust::Box<TopologyController> &tc) {
     tc->add_config(load_config("source/http"));
-    wait(1000);
     send_http_events({"hello", "world"});
   });
   auto events = read_events_from_sink();
@@ -56,11 +56,9 @@ TEST_CASE("update existing source in topology") {
   run("file_to_file", [](rust::Box<TopologyController> &tc) {
     auto config = load_config("source/http");
     tc->add_config(config);
-    wait(1000);
     uint32_t new_port = 8888;
     config = std::regex_replace(config, std::regex("9999"), std::to_string(new_port));
     tc->update_config(config);
-    wait(1000);
     send_http_events({"hello", "world"}, new_port);
   });
   auto events = read_events_from_sink();
@@ -70,9 +68,7 @@ TEST_CASE("update existing source in topology") {
 TEST_CASE("delete transform from topology") {
   run("http_to_file_with_transform", [](rust::Box<TopologyController> &tc) {
     tc->add_config(load_config("transform/add_field"));
-    wait(2000);
     tc->delete_config({"transform_remap_field"});
-    wait(2000);
     send_http_events({"e0", "e1"});
   });
   auto events = read_events_from_sink();
@@ -92,7 +88,6 @@ TEST_CASE("add two transform from topology") {
   run("http_to_file_with_transform", [](rust::Box<TopologyController> &tc) {
     auto new_config = load_config("source_with_transform/http_with_transform");
     tc->add_config(new_config);
-    wait(2000);
     std::string new_source_name = "source_http_2";
     std::string new_transform_name = "transform_add_field_2";
     std::string new_port = "8888";
@@ -103,7 +98,6 @@ TEST_CASE("add two transform from topology") {
         std::regex_replace(new_config, std::regex("transform_add_field_1"), new_transform_name);
     new_config = std::regex_replace(new_config, std::regex("1234"), new_id);
     tc->add_config(new_config);
-    wait(2000);
     send_http_events({"e0", "e1"});
   });
   auto events = read_events_from_sink();
@@ -120,7 +114,43 @@ TEST_CASE("get generation id") {
     REQUIRE(tc->get_generation_id() == 0);
     auto config = load_config("source/http");
     tc->add_config(config);
-    wait(1000);
     REQUIRE(tc->get_generation_id() == 1);
   });
+}
+
+TEST_CASE("test new topology") {
+  auto config = load_config("batch_file_to_file");
+  vectorcxx::test::setup_data();
+  REQUIRE(run_topology(config));
+  auto events = read_events_from_sink();
+  REQUIRE(events.size() == 2);
+}
+
+// test a kafka sink which is not started, which will fail on health check
+TEST_CASE("test new topology with sink not healthy") {
+  auto config = load_config("batch_file_to_kafka");
+  try {
+    auto res = run_topology(config);
+  } catch (std::exception &e) {
+    REQUIRE(strcmp(e.what(), "health check for sink failed") == 0);
+  }
+}
+
+TEST_CASE("run vector service with one time topology") {
+  run("file_to_file", [](rust::Box<TopologyController> &tc) {
+    tc->add_config(load_config("source/http"));
+    send_http_events({"hello", "world"});
+
+    // add a one time topology
+    auto config = load_config("batch_file_to_file");
+    REQUIRE(run_topology(config));
+
+    // update the long run service config
+    uint32_t new_port = 8888;
+    config = std::regex_replace(config, std::regex("9999"), std::to_string(new_port));
+    tc->update_config(config);
+    send_http_events({"hello", "world"}, new_port);
+  });
+  auto events = read_events_from_sink();
+  REQUIRE(events.size() == 6);
 }

--- a/tests/vector_test_helper.cpp
+++ b/tests/vector_test_helper.cpp
@@ -93,4 +93,8 @@ namespace vectorcxx::test {
     VectorService vector_service(config_file);
     operations(vector_service.get_controller());
   }
+
+  void setup_data() {
+    VectorService::_setup();
+  }
 } // namespace

--- a/tests/vector_test_helper.cpp
+++ b/tests/vector_test_helper.cpp
@@ -54,6 +54,13 @@ namespace vectorcxx::test {
     }
   }
 
+  static void _setup() {
+    // ensure the file sink is cleared
+    std::filesystem::remove(FILE_SINK_PATH);
+    std::filesystem::remove_all(DATA_DIR);
+    std::filesystem::create_directory(DATA_DIR);
+  }
+
   struct VectorService {
     explicit VectorService(const std::string &config_file) {
       _setup();
@@ -78,14 +85,26 @@ namespace vectorcxx::test {
       return tc.value();
     }
 
-    static void _setup() {
-      // ensure the file sink is cleared
-      std::filesystem::remove(FILE_SINK_PATH);
-      std::filesystem::remove_all(DATA_DIR);
-      std::filesystem::create_directory(DATA_DIR);
+    std::optional<rust::Box<vectorcxx::TopologyController>> tc;
+  };
+
+  struct OneShotVectorService {
+    explicit OneShotVectorService(const std::string &config_file) {
+      _setup();
+      auto config = rust::String(load_config(config_file));
+      spdlog::info("starting vector");
+
+      tc = vectorcxx::new_one_shot_topology_controller();
+      tc.value()->start(config);
     }
 
-    std::optional<rust::Box<vectorcxx::TopologyController>> tc;
+    ~OneShotVectorService() {}
+
+    rust::Box<vectorcxx::OneShotTopologyController> &get_controller() {
+      return tc.value();
+    }
+
+    std::optional<rust::Box<vectorcxx::OneShotTopologyController>> tc;
   };
 
   void run(const std::string &config_file,
@@ -94,7 +113,9 @@ namespace vectorcxx::test {
     operations(vector_service.get_controller());
   }
 
-  void setup_data() {
-    VectorService::_setup();
+  void run_one_shot(const std::string &config_file,
+           const std::function<void(rust::Box<vectorcxx::OneShotTopologyController> &)> &operations) {
+    OneShotVectorService vector_service(config_file);
+    operations(vector_service.get_controller());
   }
 } // namespace

--- a/tests/vector_test_helper.h
+++ b/tests/vector_test_helper.h
@@ -24,5 +24,7 @@ namespace vectorcxx::test {
   void run(const std::string &config_file,
            const std::function<void(rust::Box<vectorcxx::TopologyController> &)> &operations);
 
-  void setup_data();
+  void run_one_shot(const std::string &config_file,
+           const std::function<void(rust::Box<vectorcxx::OneShotTopologyController> &)> &operations);
+
 } // namespace

--- a/tests/vector_test_helper.h
+++ b/tests/vector_test_helper.h
@@ -23,4 +23,6 @@ namespace vectorcxx::test {
    */
   void run(const std::string &config_file,
            const std::function<void(rust::Box<vectorcxx::TopologyController> &)> &operations);
+
+  void setup_data();
 } // namespace


### PR DESCRIPTION
add non-long-run topology API for tasks like exporting result to kafka