### PR TITLE
Remove tikv-jemallocator feature from vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,15 +3102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37567b180c1af25924b303ddf1ee4467653783440c62360beb2b322a4d93361"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,15 +3372,6 @@ dependencies = [
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32d6a9ac92d0239d7bfa31137fb47634ac7272a3c11bcee91379ac100781670"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6607,7 +6589,6 @@ dependencies = [
  "maxminddb",
  "metrics",
  "metrics-tracing-context",
- "mimalloc",
  "mlua",
  "nats",
  "nix 0.25.0",

--- a/cmake/rust_bridge.cmake
+++ b/cmake/rust_bridge.cmake
@@ -80,22 +80,16 @@ function(add_library_rust)
     set(_LIB_NAME ${_RUST_LIB_NAME})
     set(CXXBRIDGE_TARGET ${_RUST_LIB_NAME}_bridge)
 
-    set(CXXBRIDGE_CMD_VERSION "1.0.81")
-    # install cxxbridge-cmd
-    add_custom_command(
-        OUTPUT $ENV{HOME}/.cargo/bin/cxxbridge
-        COMMAND cargo install cxxbridge-cmd@"${CXXBRIDGE_CMD_VERSION}"
-    )
-
+    # TODO: disable using non system memory allocator until we can make it work with other jemalloc libraries such as pyarrow
     # use mimalloc for macOS so that we could avoid https://github.com/vectordotdev/vector/issues/14946 when using Rosetta
-    if(APPLE)
-        message(STATUS "Use mimalloc memory allocator for vector under macOS")
-        set(MEMORY_ALLOCATOR_FEATURE "vector/mimalloc")
-    else()
-        message(STATUS "Use default memory allocator for vector under Linux")
-        # tikv-jemallocator is the default memory allocator
-        set(MEMORY_ALLOCATOR_FEATURE "")
-    endif()
+    # if(APPLE)
+    #     message(STATUS "Use mimalloc memory allocator for vector under macOS")
+    #     set(MEMORY_ALLOCATOR_FEATURE "vector/mimalloc")
+    # else()
+    #     message(STATUS "Use default memory allocator for vector under Linux")
+    #     # tikv-jemallocator is the default memory allocator
+    #     set(MEMORY_ALLOCATOR_FEATURE "")
+    # endif()
 
     ## Import Rust target
     corrosion_import_crate(

--- a/patch/CHANGELOG.md
+++ b/patch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-11-15
+* Turning jemalloc off so that system memory allocator is used, and this avoids crash when pyarrow is used together 
+# 2022-11-01
+* Upgrade to the latest version of vector (0.25 snapshot), and use rdkafka 1.9.2
 # 2022-10-31
 * `features.enterprise` is set to `[]` because one of the feature in the `enterprise` feature set cause memory allocation issue and made the app to crash
 * Pin `rdkafka` to 0.28.0 and `zstd` to `0.10.2` to aoid upgrading rdkafka to 1.9.2. Basically, we revert vector commit `ee3afe0a81d5bb20c3d8f6e6c8850a040265442d`. We should upgrade to 1.9.2 in the future. 

--- a/patch/Cargo.lock
+++ b/patch/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
 dependencies = [
  "flate2",
  "futures-core",
@@ -2880,6 +2880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,15 +4231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc093ab289b0bfda3aa1bdfab9c9542be29c7ef385cfcbe77f8c9813588eb48"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4555,15 +4552,6 @@ dependencies = [
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ce6a4b40d3bff9eb3ce9881ca0737a85072f9f975886082640cd46a75cdb35"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7786,6 +7774,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.0+5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8833,7 +8842,6 @@ dependencies = [
  "md-5",
  "metrics",
  "metrics-tracing-context",
- "mimalloc",
  "mlua",
  "mongodb",
  "nats",
@@ -8888,6 +8896,7 @@ dependencies = [
  "strip-ansi-escapes",
  "syslog",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
@@ -9338,11 +9347,11 @@ dependencies = [
  "enrichment",
  "glob",
  "lookup",
- "mimalloc",
  "prettydiff",
  "regex",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tracing-subscriber 0.3.16",
  "value",
  "vector-common",

--- a/patch/Cargo.patch.json
+++ b/patch/Cargo.patch.json
@@ -35,6 +35,7 @@
     "dependencies.rdkafka.features": ["dynamic-linking"]
   },
   "remove": {
-    "features.default": ["enterprise"]
+    "features.default": ["enterprise"],
+    "features.unix": ["tikv-jemallocator"]
   }
 }

--- a/patch/Cargo.toml
+++ b/patch/Cargo.toml
@@ -1031,9 +1031,9 @@ version = "6.0.1"
 default-features = false
 optional = true
 
-[dependencies.mimalloc]
-version = "0.1.30"
-default-features = true
+[dependencies.tikv-jemallocator]
+version = "0.5.0"
+default-features = false
 optional = true
 
 [dependencies.tokio-postgres]
@@ -1453,9 +1453,7 @@ target-powerpc-unknown-linux-gnu = [
     "vrl-cli",
     "enterprise",
 ]
-unix = [
-    "mimalloc",
-]
+unix = []
 kubernetes = [
     "dep:k8s-openapi",
     "dep:kube",


### PR DESCRIPTION
Remove tikv-jemallocator feature from vector so that it will use system default memory allocator, and this makes the built library not crash when using with other jemalloc libraries such as pywarrow.