### PR TITLE
refine config interface and support all sources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ mod ffi {
         fn stop(self: &mut TopologyController) -> bool;
 
         fn get_generation_id(self: &mut TopologyController) -> u32;
+
+        fn handle_config_reload(self: &mut TopologyController, config: &str) -> Result<bool>;
     }
 
     extern "Rust" {

--- a/tests/data/file_to_file_invalid.json
+++ b/tests/data/file_to_file_invalid.json
@@ -1,0 +1,24 @@
+{
+  "data_dir": "/tmp/vector/",
+  "sources": {
+    "source_file": {
+      "type": "file",
+      "read_from": "beginnings",
+      "include": [
+        "/tmp/vector_test_source.log"
+      ]
+    }
+  },
+  "sinks": {
+    "sink_file": {
+      "type": "file",
+      "inputs": [
+        "source_*"
+      ],
+      "encoding": {
+        "codec": "json"
+      },
+      "path": "/tmp/vector_test_sink.log"
+    }
+  }
+}


### PR DESCRIPTION
1. refine config interface, support using intact json config to reload vector.
2. support all sources(be vector repo new commit).
3. default log level set to info.
4. refine error message, expose more error details to interface layer.