### PR TITLE
fix header missing caused error on clang 16

### DIFF
--- a/tests/vector_test_helper.h
+++ b/tests/vector_test_helper.h
@@ -2,6 +2,7 @@
 
 #include "vectorcxx_bridge/lib.h"
 #include <filesystem>
+#include <functional>
 
 namespace vectorcxx::test {
   // this is the default file sink used by all testing configs


### PR DESCRIPTION
fix header missing caused error on clang 16